### PR TITLE
Cleanup Markdown

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -10,14 +10,14 @@ As operações apresentadas representam as necessidades atuais e serão atualiza
 ## Registo de um problema
 Registar uma ocorrência
 
-|Elemento| Tipo | Cardinalidade|
-|------------ | ------------|
-|dateReported|string|1....1|
-|title|string|1....1|
-|description|string|1....1|
-|description|string|1....1|
+| Elemento     | Tipo   | Cardinalidade |
+| ------------ | ------ | ------------- |
+| dateReported | string | 1....1        |
+| title        | string | 1....1        |
+| description  | string | 1....1        |
+| description  | string | 1....1        |
 
-```markdown
+``` xml
 <problem>
 	<dateReported>?</dateReported>
 	<title>?</title>
@@ -42,37 +42,36 @@ Registar uma ocorrência
 		<latitude></latitude>
 		<Longitude></longitude>
 	</location>
-</problem>  
+</problem>
 ```
 ## Atualização de um problema
 Atualizar uma ocorrência
 
-|Elemento| Tipo | Cardinalidade|
-|------------ | ------------|
-|idProblem|string|1....1|
-|changeDate|string|1....1|
-|status|string||1....1|
-|comments|string||1....1|
+| Elemento   | Tipo   | Cardinalidade |
+| ---------- | ------ | ------------- |
+| idProblem  | string | 1....1        |
+| changeDate | string | 1....1        |
+| status     | string | 1....1        |
+| comments   | string | 1....1        |
 
-```markdown
+``` xml
 <update>
 	<idProblem></idProblem>
 	<changeDate></changeDate>
 	<status>?</status>
 	<comments></comments>
-</update>  
-
+</update>
 ```
 ## Obter ocorrências
 Obter ocorrências
 
-|Elemento| Tipo | Cardinalidade|
-|------------ | ------------|
-|district|string|1....1|
-|county|string|1....1|
-|parish|string|1....1|
+| Elemento    | Tipo   | Cardinalidade |
+| ----------- | ------ | ------------- |
+| district    | string | 1....1        |
+| county      | string | 1....1        |
+| parish      | string | 1....1        |
 
-```markdown
+``` xml
 <search>
 	<district></district>
 	<county></county>
@@ -82,49 +81,49 @@ Obter ocorrências
 	<dateReportedEnd></dateReportedEnd>
 	<dateSolvedStart></dateSolvedStart>
 	<dateSolvedEnd></dateSolvedEnd>
-</search>  
+</search>
 ```
 
 ## Obter imagem de um problema
 Obter a imagem associada ao problema reportado
 
-|Elemento| Tipo | Cardinalidade|
-|------------ | ------------|
-|problemID|string|1....1|
+| Elemento  | Tipo   | Cardinalidade |
+| --------- | ------ | ------------- |
+| problemID | string | 1....1        |
 
-```markdown
+``` xml
 <getImage>
 	<problemID></problemID>
-</getImage> 
+</getImage>
 ```
 ## Obter feedbkack
 Obter feedback de uma ocorrência
 
-|Elemento| Tipo | Cardinalidade|
-|------------ | ------------|
-|problemID|string|1....1|
+| Elemento  | Tipo   | Cardinalidade |
+| --------- | ------ | ------------- |
+| problemID | string | 1....1        |
 
-```markdown
+``` xml
 <getFeedback>
 	<problemID></problemID>
-</getFeedback> 
+</getFeedback>
 ```
 
 ## Enviar comentários
 Colocar um comentário para o cidadão
 
-|Elemento| Tipo | Cardinalidade|
-|------------ | ------------|
-|problemID|string|1....1|
+| Elemento  | Tipo   | Cardinalidade |
+| --------- | ------ | ------------- |
+| problemID | string | 1....1        |
 
-```markdown
+``` xml
 <sendComments>
 	<district></district>
 	<county></county>
 	<parish></parish>
 	<problemID></problemID>
 	<comments></comments>
-</sendComments> 
+</sendComments>
 ```
 
 ## Obter categorias
@@ -138,83 +137,80 @@ Obter os distritos existentes de um distrito,
 ## Obter concelhos
 Obter os concelhos existentes de um distrito , através do par DI do código dicofre.
 
-|Elemento| Tipo | Cardinalidade|
-|------------ | ------------|
-|DI|string|1....1|
+| Elemento | Tipo   | Cardinalidade |
+| -------- | ------ | ------------- |
+| DI       | string | 1....1        |
 
 
-```markdown
+``` xml
 <county>
 	<DI>10</DI>
 </county>
-
 ```
 
 ## Obter Freguesia|s de um determinado concelho
 Obter os distritos existentes de um distrito,
 
-|Elemento| Tipo | Cardinalidade|
-|------------ | ------------|
-|DI|string|1....1|
-|CO|string|1....1|
+| Elemento | Tipo   | Cardinalidade |
+| -------- | ------ | ------------- |
+| DI       | string | 1....1        |
+| CO       | string | 1....1        |
 
 
-```markdown
-  <parish>
-			<DI>?</amr:DI>
-            <CO>?</amr:CO>
-  </parish>
-
+``` xml
+<parish>
+	<DI>?</amr:DI>
+	<CO>?</amr:CO>
+</parish>
 ```
-
 
 
 ## Categorias
 
-| ID | Descrição|
-|------------ | ------------|
-|2|	Animais Abandonados|
-|3|	Limpeza de Valetas, Bermas e Caminhos|
-|4|	Conservação da Iluminação Pública|
-|5|	Limpeza e Conservação de Espaços Públicos|
-|6|	Saneamento, Ruturas de Águas ou Desvio de Tampas|
-|7|	Sinalização de Trânsito|
-|8|	Conservação de Parque Escolar|
-|9|	Conservação das Ruas e Pavimento|
-|10|Publicidade, Outdoors e Cartazes|
-|11|Manutenção de Ciclovias|
-|12|Recolha de Lixo|
-|13|Manutenção, Rega e Limpeza de Jardins|
-|14|Nomes ou Numeração de Ruas|
-|15|Estacionamento de Veículos|
-|16|Acessos para Cidadãos com Mobilidade Reduzida|
-|17|Manutenção e Limpeza de Contentores e Ecopontos|
-|19|Poluição Sonora|
+| ID | Descrição                                        |
+| -- | ------------------------------------------------ |
+| 2  | Animais Abandonados                              |
+| 3  | Limpeza de Valetas, Bermas e Caminhos            |
+| 4  | Conservação da Iluminação Pública                |
+| 5  | Limpeza e Conservação de Espaços Públicos        |
+| 6  | Saneamento, Ruturas de Águas ou Desvio de Tampas |
+| 7  | Sinalização de Trânsito                          |
+| 8  | Conservação de Parque Escolar                    |
+| 9  | Conservação das Ruas e Pavimento                 |
+| 10 | Publicidade, Outdoors e Cartazes                 |
+| 11 | Manutenção de Ciclovias                          |
+| 12 | Recolha de Lixo                                  |
+| 13 | Manutenção, Rega e Limpeza de Jardins            |
+| 14 | Nomes ou Numeração de Ruas                       |
+| 15 | Estacionamento de Veículos                       |
+| 16 | Acessos para Cidadãos com Mobilidade Reduzida    |
+| 17 | Manutenção e Limpeza de Contentores e Ecopontos  |
+| 19 | Poluição Sonora                                  |
 
 ## Estados
 
-| ID | Descrição|
-|------------ | ------------|
-|0|Submetido|
-|1|Em Análise|
-|2|Resolvido|
-|3|Não Aplicável|
-|4|Reencaminhado|
+| ID | Descrição     |
+| -- | ------------- |
+| 0  | Submetido     |
+| 1  | Em Análise    |
+| 2  | Resolvido     |
+| 3  | Não Aplicável |
+| 4  | Reencaminhado |
 
 ## Tipo de Morada
 
-| ID | Descrição|
-|------------ | ------------|
-|M|Municipio|
-|F|Freguesia|
+| ID | Descrição |
+| -- | --------- |
+| M  | Municipio |
+| F  | Freguesia |
 
 
 ## Privado
 
-| ID | Descrição|
-|------------ | ------------|
-|1|Sim|
-|0|Não|
+| ID | Descrição |
+| -- | ----------|
+| 1  | Sim       |
+| 0  | Não       |
 
 # Modelo de dados
 ![GSD1 phenotype]({{ BASE_PATH }}/ISCAPI/assets/images/amr.png)


### PR DESCRIPTION
- Fixed the tables.
- Made them more readable.
- Switched highlighting of XML snippets from `markdown` to `xml`.
- Cleaned up trailing whitespace.